### PR TITLE
Feature/improve-data-source-search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+examples/test
 
 # Test binary, built with `go test -c`
 *.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Changelog
 
-## 04.09.2022, Version 2.1.2
+## 04.09.2022, Version 2.2.0
 
-- improve data source search for:
-  - alert actions
-  - alert sources
-  - connectors
-  - escalation policies
-  - incident templates
-  - schedules
-  - services
-  - status pages
-  - teams
-  - uptime monitors
-  - users
+- add search by name for all entities
 
 ## 30.08.2022, Version 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 04.09.2022, Version 2.1.2
+
+- improve data source search for:
+  - alert actions
+  - alert sources
+  - connectors
+  - escalation policies
+  - incident templates
+  - schedules
+  - services
+  - status pages
+  - teams
+  - uptime monitors
+  - users
+
 ## 30.08.2022, Version 2.1.1
 
 - add various validation lists to schedule

--- a/alertaction.go
+++ b/alertaction.go
@@ -340,6 +340,44 @@ func (c *Client) GetAlertActions(input *GetAlertActionsInput) (*GetAlertActionsO
 	return &GetAlertActionsOutput{AlertActions: alertActions}, nil
 }
 
+// SearchAlertActionInput represents the input of a SearchAlertAction operation.
+type SearchAlertActionInput struct {
+	_               struct{}
+	AlertActionName *string
+}
+
+// SearchAlertActionOutput represents the output of a SearchAlertAction operation.
+type SearchAlertActionOutput struct {
+	_           struct{}
+	AlertAction *AlertAction
+}
+
+// SearchAlertAction gets the alertAction with specified name.
+func (c *Client) SearchAlertAction(input *SearchAlertActionInput) (*SearchAlertActionOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.AlertActionName == nil {
+		return nil, errors.New("alert action name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.alertActions, *input.AlertActionName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	alertAction := &AlertAction{}
+	err = json.Unmarshal(resp.Body(), alertAction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchAlertActionOutput{AlertAction: alertAction}, nil
+}
+
 // UpdateAlertActionInput represents the input of a UpdateAlertAction operation.
 type UpdateAlertActionInput struct {
 	_             struct{}

--- a/alertsource.go
+++ b/alertsource.go
@@ -499,6 +499,44 @@ func (c *Client) GetAlertSources(input *GetAlertSourcesInput) (*GetAlertSourcesO
 	return &GetAlertSourcesOutput{AlertSources: alertSources}, nil
 }
 
+// SearchAlertSourceInput represents the input of a SearchAlertSource operation.
+type SearchAlertSourceInput struct {
+	_               struct{}
+	AlertSourceName *string
+}
+
+// SearchAlertSourceOutput represents the output of a SearchAlertSource operation.
+type SearchAlertSourceOutput struct {
+	_           struct{}
+	AlertSource *AlertSource
+}
+
+// SearchAlertSource gets the alertSource with specified name.
+func (c *Client) SearchAlertSource(input *SearchAlertSourceInput) (*SearchAlertSourceOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.AlertSourceName == nil {
+		return nil, errors.New("alert source name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.alertSources, *input.AlertSourceName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	alertSource := &AlertSource{}
+	err = json.Unmarshal(resp.Body(), alertSource)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchAlertSourceOutput{AlertSource: alertSource}, nil
+}
+
 // UpdateAlertSourceInput represents the input of a UpdateAlertSource operation.
 type UpdateAlertSourceInput struct {
 	_             struct{}

--- a/connector.go
+++ b/connector.go
@@ -316,6 +316,44 @@ func (c *Client) GetConnectors(input *GetConnectorsInput) (*GetConnectorsOutput,
 	return &GetConnectorsOutput{Connectors: connectors}, nil
 }
 
+// SearchConnectorInput represents the input of a SearchConnector operation.
+type SearchConnectorInput struct {
+	_             struct{}
+	ConnectorName *string
+}
+
+// SearchConnectorOutput represents the output of a SearchConnector operation.
+type SearchConnectorOutput struct {
+	_         struct{}
+	Connector *Connector
+}
+
+// SearchConnector gets the connector with specified name.
+func (c *Client) SearchConnector(input *SearchConnectorInput) (*SearchConnectorOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.ConnectorName == nil {
+		return nil, errors.New("Connector name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.connectors, *input.ConnectorName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	connector := &Connector{}
+	err = json.Unmarshal(resp.Body(), connector)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchConnectorOutput{Connector: connector}, nil
+}
+
 // UpdateConnectorInput represents the input of a UpdateConnector operation.
 type UpdateConnectorInput struct {
 	_           struct{}

--- a/escalationpolicy.go
+++ b/escalationpolicy.go
@@ -128,6 +128,44 @@ func (c *Client) GetEscalationPolicies(input *GetEscalationPoliciesInput) (*GetE
 	return &GetEscalationPoliciesOutput{EscalationPolicies: escalationPolicies}, nil
 }
 
+// SearchEscalationPolicyInput represents the input of a SearchEscalationPolicy operation.
+type SearchEscalationPolicyInput struct {
+	_                    struct{}
+	EscalationPolicyName *string
+}
+
+// SearchEscalationPolicyOutput represents the output of a SearchEscalationPolicy operation.
+type SearchEscalationPolicyOutput struct {
+	_                struct{}
+	EscalationPolicy *EscalationPolicy
+}
+
+// SearchEscalationPolicy gets the escalationPolicy with specified name.
+func (c *Client) SearchEscalationPolicy(input *SearchEscalationPolicyInput) (*SearchEscalationPolicyOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.EscalationPolicyName == nil {
+		return nil, errors.New("escalation policy name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.escalationPolicies, *input.EscalationPolicyName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	escalationPolicy := &EscalationPolicy{}
+	err = json.Unmarshal(resp.Body(), escalationPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchEscalationPolicyOutput{EscalationPolicy: escalationPolicy}, nil
+}
+
 // UpdateEscalationPolicyInput represents the input of a UpdateEscalationPolicy operation.
 type UpdateEscalationPolicyInput struct {
 	_                  struct{}

--- a/incidenttemplate.go
+++ b/incidenttemplate.go
@@ -146,6 +146,44 @@ func (c *Client) GetIncidentTemplate(input *GetIncidentTemplateInput) (*GetIncid
 	return &GetIncidentTemplateOutput{IncidentTemplate: incidentTemplate}, nil
 }
 
+// SearchIncidentTemplateInput represents the input of a SearchIncidentTemplate operation.
+type SearchIncidentTemplateInput struct {
+	_                    struct{}
+	IncidentTemplateName *string
+}
+
+// SearchIncidentTemplateOutput represents the output of a SearchIncidentTemplate operation.
+type SearchIncidentTemplateOutput struct {
+	_                struct{}
+	IncidentTemplate *IncidentTemplate
+}
+
+// SearchIncidentTemplate gets the incidentTemplate with specified name.
+func (c *Client) SearchIncidentTemplate(input *SearchIncidentTemplateInput) (*SearchIncidentTemplateOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.IncidentTemplateName == nil {
+		return nil, errors.New("incident template name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.incidentTemplates, *input.IncidentTemplateName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	incidentTemplate := &IncidentTemplate{}
+	err = json.Unmarshal(resp.Body(), incidentTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchIncidentTemplateOutput{IncidentTemplate: incidentTemplate}, nil
+}
+
 // UpdateIncidentTemplateInput represents the input of a UpdateIncidentTemplate operation.
 type UpdateIncidentTemplateInput struct {
 	_                  struct{}

--- a/schedule.go
+++ b/schedule.go
@@ -359,6 +359,44 @@ func (c *Client) GetScheduleUserOnCall(input *GetScheduleUserOnCallInput) (*GetS
 	return &GetScheduleUserOnCallOutput{Shift: shift}, nil
 }
 
+// SearchScheduleInput represents the input of a SearchSchedule operation.
+type SearchScheduleInput struct {
+	_            struct{}
+	ScheduleName *string
+}
+
+// SearchScheduleOutput represents the output of a SearchSchedule operation.
+type SearchScheduleOutput struct {
+	_        struct{}
+	Schedule *Schedule
+}
+
+// SearchSchedule gets the schedule with specified name.
+func (c *Client) SearchSchedule(input *SearchScheduleInput) (*SearchScheduleOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.ScheduleName == nil {
+		return nil, errors.New("schedule name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.schedules, *input.ScheduleName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	schedule := &Schedule{}
+	err = json.Unmarshal(resp.Body(), schedule)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchScheduleOutput{Schedule: schedule}, nil
+}
+
 // UpdateScheduleInput represents the input of a UpdateSchedule operation.
 type UpdateScheduleInput struct {
 	_           struct{}

--- a/service.go
+++ b/service.go
@@ -264,6 +264,44 @@ func (c *Client) GetServiceSubscribers(input *GetServiceSubscribersInput) (*GetS
 	return &GetServiceSubscribersOutput{Subscribers: subscribers}, nil
 }
 
+// SearchServiceInput represents the input of a SearchService operation.
+type SearchServiceInput struct {
+	_           struct{}
+	ServiceName *string
+}
+
+// SearchServiceOutput represents the output of a SearchService operation.
+type SearchServiceOutput struct {
+	_       struct{}
+	Service *Service
+}
+
+// SearchService gets the service with specified name.
+func (c *Client) SearchService(input *SearchServiceInput) (*SearchServiceOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.ServiceName == nil {
+		return nil, errors.New("service name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.services, *input.ServiceName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	service := &Service{}
+	err = json.Unmarshal(resp.Body(), service)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchServiceOutput{Service: service}, nil
+}
+
 // UpdateServiceInput represents the input of a UpdateService operation.
 type UpdateServiceInput struct {
 	_         struct{}

--- a/statuspage.go
+++ b/statuspage.go
@@ -228,6 +228,44 @@ func (c *Client) GetStatusPageSubscribers(input *GetStatusPageSubscribersInput) 
 	return &GetStatusPageSubscribersOutput{Subscribers: subscribers}, nil
 }
 
+// SearchStatusPageInput represents the input of a SearchStatusPage operation.
+type SearchStatusPageInput struct {
+	_              struct{}
+	StatusPageName *string
+}
+
+// SearchStatusPageOutput represents the output of a SearchStatusPage operation.
+type SearchStatusPageOutput struct {
+	_          struct{}
+	StatusPage *StatusPage
+}
+
+// SearchStatusPage gets the statusPage with specified name.
+func (c *Client) SearchStatusPage(input *SearchStatusPageInput) (*SearchStatusPageOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.StatusPageName == nil {
+		return nil, errors.New("status page name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.statusPages, *input.StatusPageName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	statusPage := &StatusPage{}
+	err = json.Unmarshal(resp.Body(), statusPage)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchStatusPageOutput{StatusPage: statusPage}, nil
+}
+
 // UpdateStatusPageInput represents the input of a UpdateStatusPage operation.
 type UpdateStatusPageInput struct {
 	_            struct{}

--- a/team.go
+++ b/team.go
@@ -190,7 +190,7 @@ func (c *Client) SearchTeam(input *SearchTeamInput) (*SearchTeamOutput, error) {
 		return nil, errors.New("input is required")
 	}
 	if input.TeamName == nil {
-		return nil, errors.New("Team name is required")
+		return nil, errors.New("team name is required")
 	}
 
 	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.teams, *input.TeamName))

--- a/team.go
+++ b/team.go
@@ -172,6 +172,44 @@ func (c *Client) GetTeams(input *GetTeamsInput) (*GetTeamsOutput, error) {
 	return &GetTeamsOutput{Teams: teams}, nil
 }
 
+// SearchTeamInput represents the input of a SearchTeam operation.
+type SearchTeamInput struct {
+	_        struct{}
+	TeamName *string
+}
+
+// SearchTeamOutput represents the output of a SearchTeam operation.
+type SearchTeamOutput struct {
+	_    struct{}
+	Team *Team
+}
+
+// SearchTeam gets the team with specified name.
+func (c *Client) SearchTeam(input *SearchTeamInput) (*SearchTeamOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.TeamName == nil {
+		return nil, errors.New("Team name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.teams, *input.TeamName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	team := &Team{}
+	err = json.Unmarshal(resp.Body(), team)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchTeamOutput{Team: team}, nil
+}
+
 // UpdateTeamInput represents the input of a UpdateTeam operation.
 type UpdateTeamInput struct {
 	_      struct{}

--- a/uptimemonitor.go
+++ b/uptimemonitor.go
@@ -208,6 +208,44 @@ func (c *Client) GetUptimeMonitors(input *GetUptimeMonitorsInput) (*GetUptimeMon
 	return &GetUptimeMonitorsOutput{UptimeMonitors: uptimeMonitors}, nil
 }
 
+// SearchUptimeMonitorInput represents the input of a SearchUptimeMonitor operation.
+type SearchUptimeMonitorInput struct {
+	_                 struct{}
+	UptimeMonitorName *string
+}
+
+// SearchUptimeMonitorOutput represents the output of a SearchUptimeMonitor operation.
+type SearchUptimeMonitorOutput struct {
+	_             struct{}
+	UptimeMonitor *UptimeMonitor
+}
+
+// SearchUptimeMonitor gets the UptimeMonitor with specified name.
+func (c *Client) SearchUptimeMonitor(input *SearchUptimeMonitorInput) (*SearchUptimeMonitorOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.UptimeMonitorName == nil {
+		return nil, errors.New("uptime monitor name is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.uptimeMonitors, *input.UptimeMonitorName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	uptimeMonitor := &UptimeMonitor{}
+	err = json.Unmarshal(resp.Body(), uptimeMonitor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchUptimeMonitorOutput{UptimeMonitor: uptimeMonitor}, nil
+}
+
 // UpdateUptimeMonitorInput represents the input of a UpdateUptimeMonitor operation.
 type UpdateUptimeMonitorInput struct {
 	_               struct{}

--- a/user.go
+++ b/user.go
@@ -266,6 +266,44 @@ func (c *Client) GetUsers(input *GetUsersInput) (*GetUsersOutput, error) {
 	return &GetUsersOutput{Users: users}, nil
 }
 
+// SearchUserInput represents the input of a SearchUser operation.
+type SearchUserInput struct {
+	_        struct{}
+	UserName *string
+}
+
+// SearchUserOutput represents the output of a SearchUser operation.
+type SearchUserOutput struct {
+	_    struct{}
+	User *User
+}
+
+// SearchUser gets the user with specified name.
+func (c *Client) SearchUser(input *SearchUserInput) (*SearchUserOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.UserName == nil {
+		return nil, errors.New("username is required")
+	}
+
+	resp, err := c.httpClient.R().Get(fmt.Sprintf("%s/name/%s", apiRoutes.users, *input.UserName))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	user := &User{}
+	err = json.Unmarshal(resp.Body(), user)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SearchUserOutput{User: user}, nil
+}
+
 // UpdateUserInput represents the input of a UpdateUser operation.
 type UpdateUserInput struct {
 	_        struct{}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v2.1.2"
+const Version = "v2.2.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v2.1.1"
+const Version = "v2.1.2"


### PR DESCRIPTION
Rework data sources in terraform provider to improve scalability using newly built search query from API.
Url: api/xxx/name/{name}

Following entities are affected:

- [x] alert sources
- [x] escalation policies
- [x] incident templates
- [x] schedules
- [x] service
- [x] status page
- [x] team
- [x] uptime monitor
- [x] user
- [x] connectors
- [x] alert actions