### PR TITLE
Fix/metrics missing field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13.03.2023, Version 3.0.1
+
+- add missing field `integrationKey` to metric resource in [#24](https://github.com/iLert/ilert-go/pull/24)
+
 ## 08.03.2023, Version 3.0.0 - API user preference migration: see [migration changes](https://docs.ilert.com/rest-api/api-version-history/api-user-preference-migration-2023#migrating-ilert-go-and-or-terraform) for a detailed migration guide
 
 - removed notification settings fields from user resource

--- a/metric.go
+++ b/metric.go
@@ -22,6 +22,7 @@ type Metric struct {
 	ShowValuesOnMouseOver bool                    `json:"showValuesOnMouseOver,omitempty"`
 	Teams                 []TeamShort             `json:"teams,omitempty"`
 	UnitLabel             string                  `json:"unitLabel,omitempty"`
+	IntegrationKey        string                  `json:"integrationKey,omitempty"`
 	Metadata              *MetricProviderMetadata `json:"metadata,omitempty"`
 	DataSource            *MetricDataSource       `json:"dataSource,omitempty"`
 }

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.0.0"
+const Version = "v3.0.1"


### PR DESCRIPTION
- includes for field `integrationKey` in metric were already implemented, but field was not defined
