### PR TITLE
Feature/alert actions v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 16.10.2023, Version 3.1.0
+
+- add new fields `delayMin` and `routingKey` to escalation policy resource in [#26](https://github.com/iLert/ilert-go/pull/26)
+- add templates and alert grouping to alert source resource in [#27](https://github.com/iLert/ilert-go/pull/27)
+- add new trigger types to alert action resource in [#28](https://github.com/iLert/ilert-go/pull/28)
+- add alertSources and teams fields, deprecate alertSourceIds in [#29](https://github.com/iLert/ilert-go/pull/29)
+
 ## 02.05.2023, Version 3.0.2
 
 - add missing field `accountWideView` to status page resource in [#25](https://github.com/iLert/ilert-go/pull/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 11.01.2024, Version 3.5.0
+
+- apply alert actions v2 changes in [#29](https://github.com/iLert/ilert-go/pull/29)
+  - add alertSources and teams fields, deprecate alertSourceIds
+
 # 05.01.2024, Version 3.4.1
 
 - replace `ThemeMode` field with `Appearance` for status page resource in [#35](https://github.com/iLert/ilert-go/pull/35)
@@ -23,7 +28,6 @@
 - add new fields `delayMin` and `routingKey` to escalation policy resource in [#26](https://github.com/iLert/ilert-go/pull/26)
 - add templates and alert grouping to alert source resource in [#27](https://github.com/iLert/ilert-go/pull/27)
 - add new trigger types to alert action resource in [#28](https://github.com/iLert/ilert-go/pull/28)
-- add alertSources and teams fields, deprecate alertSourceIds in [#29](https://github.com/iLert/ilert-go/pull/29)
 
 ## 02.05.2023, Version 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# 01.02.2024, Version 3.6.0
+
 - apply alert actions v2 changes in [#29](https://github.com/iLert/ilert-go/pull/29)
   - add alertSources and teams fields, deprecate alertSourceIds
 

--- a/alert_action.go
+++ b/alert_action.go
@@ -10,17 +10,19 @@ import (
 
 // AlertAction definition https://api.ilert.com/api-docs/#tag/Alert-Actions
 type AlertAction struct {
-	ID             string       `json:"id,omitempty"`
-	Name           string       `json:"name"`
-	AlertSourceIDs []int64      `json:"alertSourceIds"`
-	ConnectorID    string       `json:"connectorId"`
-	ConnectorType  string       `json:"connectorType"`
-	TriggerMode    string       `json:"triggerMode"`
-	TriggerTypes   []string     `json:"triggerTypes,omitempty"`
-	CreatedAt      string       `json:"createdAt,omitempty"` // date time string in ISO 8601
-	UpdatedAt      string       `json:"updatedAt,omitempty"` // date time string in ISO 8601
-	Params         interface{}  `json:"params"`
-	AlertFilter    *AlertFilter `json:"alertFilter,omitempty"`
+	ID             string        `json:"id,omitempty"`
+	Name           string        `json:"name"`
+	AlertSourceIDs []int64       `json:"alertSourceIds"`
+	AlertSources   []AlertSource `json:"alertSources"`
+	ConnectorID    string        `json:"connectorId"`
+	ConnectorType  string        `json:"connectorType"`
+	TriggerMode    string        `json:"triggerMode"`
+	TriggerTypes   []string      `json:"triggerTypes,omitempty"`
+	CreatedAt      string        `json:"createdAt,omitempty"` // date time string in ISO 8601
+	UpdatedAt      string        `json:"updatedAt,omitempty"` // date time string in ISO 8601
+	Params         interface{}   `json:"params"`
+	AlertFilter    *AlertFilter  `json:"alertFilter,omitempty"`
+	Teams          []TeamShort   `json:"teams,omitempty"`
 }
 
 // AlertActionOutput definition https://api.ilert.com/api-docs/#tag/Alert-Actions
@@ -28,6 +30,7 @@ type AlertActionOutput struct {
 	ID             string                   `json:"id"`
 	Name           string                   `json:"name"`
 	AlertSourceIDs []int64                  `json:"alertSourceIds"`
+	AlertSources   []AlertSource            `json:"alertSources"`
 	ConnectorID    string                   `json:"connectorId"`
 	ConnectorType  string                   `json:"connectorType"`
 	TriggerMode    string                   `json:"triggerMode"`
@@ -36,6 +39,7 @@ type AlertActionOutput struct {
 	UpdatedAt      string                   `json:"updatedAt"` // date time string in ISO 8601
 	Params         *AlertActionOutputParams `json:"params"`
 	AlertFilter    *AlertFilter             `json:"alertFilter,omitempty"`
+	Teams          []TeamShort              `json:"teams,omitempty"`
 }
 
 // AlertActionOutputParams definition

--- a/alert_action.go
+++ b/alert_action.go
@@ -12,8 +12,8 @@ import (
 type AlertAction struct {
 	ID             string        `json:"id,omitempty"`
 	Name           string        `json:"name"`
-	AlertSourceIDs []int64       `json:"alertSourceIds"` // @deprecated
-	AlertSources   []AlertSource `json:"alertSources"`
+	AlertSourceIDs []int64       `json:"alertSourceIds,omitempty"` // @deprecated
+	AlertSources   []AlertSource `json:"alertSources,omitempty"`
 	ConnectorID    string        `json:"connectorId,omitempty"`
 	ConnectorType  string        `json:"connectorType"`
 	TriggerMode    string        `json:"triggerMode"`
@@ -29,8 +29,8 @@ type AlertAction struct {
 type AlertActionOutput struct {
 	ID             string                   `json:"id"`
 	Name           string                   `json:"name"`
-	AlertSourceIDs []int64                  `json:"alertSourceIds"`
-	AlertSources   []AlertSource            `json:"alertSources"`
+	AlertSourceIDs []int64                  `json:"alertSourceIds,omitempty"` // @deprecated
+	AlertSources   []AlertSource            `json:"alertSources,omitempty"`
 	ConnectorID    string                   `json:"connectorId"`
 	ConnectorType  string                   `json:"connectorType"`
 	TriggerMode    string                   `json:"triggerMode"`

--- a/alert_action.go
+++ b/alert_action.go
@@ -14,7 +14,7 @@ type AlertAction struct {
 	Name           string        `json:"name"`
 	AlertSourceIDs []int64       `json:"alertSourceIds"` // @deprecated
 	AlertSources   []AlertSource `json:"alertSources"`
-	ConnectorID    string        `json:"connectorId"`
+	ConnectorID    string        `json:"connectorId,omitempty"`
 	ConnectorType  string        `json:"connectorType"`
 	TriggerMode    string        `json:"triggerMode"`
 	TriggerTypes   []string      `json:"triggerTypes,omitempty"`

--- a/alert_action.go
+++ b/alert_action.go
@@ -12,7 +12,7 @@ import (
 type AlertAction struct {
 	ID             string        `json:"id,omitempty"`
 	Name           string        `json:"name"`
-	AlertSourceIDs []int64       `json:"alertSourceIds"`
+	AlertSourceIDs []int64       `json:"alertSourceIds"` // @deprecated
 	AlertSources   []AlertSource `json:"alertSources"`
 	ConnectorID    string        `json:"connectorId"`
 	ConnectorType  string        `json:"connectorType"`

--- a/examples/alert_action/main.go
+++ b/examples/alert_action/main.go
@@ -53,12 +53,12 @@ func main() {
 
 	rcn, err := client.CreateAlertAction(&ilert.CreateAlertActionInput{
 		AlertAction: &ilert.AlertAction{
-			Name:           "Test GitHub AlertAction",
-			ConnectorType:  ilert.ConnectorTypes.Github,
-			ConnectorID:    rcr.Connector.ID,
-			TriggerMode:    ilert.AlertActionTriggerModes.Automatic,
-			TriggerTypes:   ilert.AlertActionTriggerTypesAll,
-			AlertSourceIDs: []int64{ras.AlertSource.ID},
+			Name:          "Test GitHub AlertAction",
+			ConnectorType: ilert.ConnectorTypes.Github,
+			ConnectorID:   rcr.Connector.ID,
+			TriggerMode:   ilert.AlertActionTriggerModes.Automatic,
+			TriggerTypes:  ilert.AlertActionTriggerTypesAll,
+			AlertSources:  []ilert.AlertSource{*ras.AlertSource},
 			Params: ilert.AlertActionParamsGithub{
 				Owner:      "my-org",
 				Repository: "my-repo",

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.0.3"
+const Version = "v3.1.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.5.0"
+const Version = "v3.6.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.4.1"
+const Version = "v3.5.0"


### PR DESCRIPTION
- add `alertSources` and `teams` fields, deprecate `alertSourceIds`

- NOTE: release, when alert actions v2 migration is done 