### PR TITLE
Feature/new api resources pt.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - new alert grouping type `intelligentGrouping`
       - add field `scoreThreshold`
     - add event filter
+    - add includes for POST and PUT API calls
   - status page
     - add email login via `emailWhitelist`
     - add `announcement` fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 29.07.2024, Version 3.9.0
+## 22.08.2024, Version 3.9.0
 
 - add new api resources/fields pt.1 [#42](https://github.com/iLert/ilert-go/pull/42)
   - alert action
@@ -14,6 +14,7 @@
   - status page
     - add email login via `emailWhitelist`
     - add `announcement` fields
+    - add `metrics`
 
 ## 09.05.2024, Version 3.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 29.07.2024, Version 3.9.0
 
-- add new api resources/fields pt.1 [#42](https://github.com/iLert/ilert-go/pull/41)
+- add new api resources/fields pt.1 [#42](https://github.com/iLert/ilert-go/pull/42)
   - alert action
     - deprecate `delaySec` in favor of more specific `escalationEndedDelaySec` and `notResolvedDelaySec`
     - new trigger type `AlertNotResolved`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@
 
 - add region to user [#41](https://github.com/iLert/ilert-go/pull/41)
 
-## 09.05.2024, Version 3.8.1
-
-- add region to user [#41](https://github.com/iLert/ilert-go/pull/41)
-
 ## 06.05.2024, Version 3.8.0
 
 - add send-no-invitation option to user create api [#40](https://github.com/iLert/ilert-go/pull/40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 29.07.2024, Version 3.9.0
+
+- add new api resources/fields pt.1 [#42](https://github.com/iLert/ilert-go/pull/41)
+  - alert action
+    - deprecate `delaySec` in favor of more specific `escalationEndedDelaySec` and `notResolvedDelaySec`
+    - new trigger type `AlertNotResolved`
+    - new alert action type `SlackWebhook`
+  - alert source
+    - new alert grouping type `intelligentGrouping`
+      - add field `scoreThreshold`
+    - add event filter
+  - status page
+    - add email login via `emailWhitelist`
+    - add `announcement` fields
+
+## 09.05.2024, Version 3.8.1
+
+- add region to user [#41](https://github.com/iLert/ilert-go/pull/41)
+
 ## 09.05.2024, Version 3.8.1
 
 - add region to user [#41](https://github.com/iLert/ilert-go/pull/41)

--- a/alert_action.go
+++ b/alert_action.go
@@ -10,38 +10,42 @@ import (
 
 // AlertAction definition https://api.ilert.com/api-docs/#tag/Alert-Actions
 type AlertAction struct {
-	ID             string         `json:"id,omitempty"`
-	Name           string         `json:"name"`
-	AlertSourceIDs []int64        `json:"alertSourceIds,omitempty"` // @deprecated
-	AlertSources   *[]AlertSource `json:"alertSources,omitempty"`
-	ConnectorID    string         `json:"connectorId,omitempty"`
-	ConnectorType  string         `json:"connectorType"`
-	TriggerMode    string         `json:"triggerMode"`
-	DelaySec       int            `json:"delaySec,omitempty"` // between 0 and 7200, only allowed with triggerType 'alert-escalation-ended'
-	TriggerTypes   []string       `json:"triggerTypes,omitempty"`
-	CreatedAt      string         `json:"createdAt,omitempty"` // date time string in ISO 8601
-	UpdatedAt      string         `json:"updatedAt,omitempty"` // date time string in ISO 8601
-	Params         interface{}    `json:"params"`
-	AlertFilter    *AlertFilter   `json:"alertFilter,omitempty"`
-	Teams          *[]TeamShort   `json:"teams,omitempty"`
+	ID                      string         `json:"id,omitempty"`
+	Name                    string         `json:"name"`
+	AlertSourceIDs          []int64        `json:"alertSourceIds,omitempty"` // @deprecated
+	AlertSources            *[]AlertSource `json:"alertSources,omitempty"`
+	ConnectorID             string         `json:"connectorId,omitempty"`
+	ConnectorType           string         `json:"connectorType"`
+	TriggerMode             string         `json:"triggerMode"`
+	DelaySec                int            `json:"delaySec,omitempty"`                // @deprecated
+	EscalationEndedDelaySec int            `json:"escalationEndedDelaySec,omitempty"` // between 0 and 7200, used with triggerType 'AlertEscalationEnded'
+	NotResolvedDelaySec     int            `json:"notResolvedDelaySec,omitempty"`     // between 0 and 7200, used with triggerType 'AlertNotResolved'
+	TriggerTypes            []string       `json:"triggerTypes,omitempty"`
+	CreatedAt               string         `json:"createdAt,omitempty"` // date time string in ISO 8601
+	UpdatedAt               string         `json:"updatedAt,omitempty"` // date time string in ISO 8601
+	Params                  interface{}    `json:"params"`
+	AlertFilter             *AlertFilter   `json:"alertFilter,omitempty"`
+	Teams                   *[]TeamShort   `json:"teams,omitempty"`
 }
 
 // AlertActionOutput definition https://api.ilert.com/api-docs/#tag/Alert-Actions
 type AlertActionOutput struct {
-	ID             string                   `json:"id"`
-	Name           string                   `json:"name"`
-	AlertSourceIDs []int64                  `json:"alertSourceIds,omitempty"` // @deprecated
-	AlertSources   *[]AlertSource           `json:"alertSources,omitempty"`
-	ConnectorID    string                   `json:"connectorId"`
-	ConnectorType  string                   `json:"connectorType"`
-	TriggerMode    string                   `json:"triggerMode"`
-	DelaySec       int                      `json:"delaySec,omitempty"` // between 0 and 7200, only allowed with triggerType 'alert-escalation-ended'
-	TriggerTypes   []string                 `json:"triggerTypes,omitempty"`
-	CreatedAt      string                   `json:"createdAt"` // date time string in ISO 8601
-	UpdatedAt      string                   `json:"updatedAt"` // date time string in ISO 8601
-	Params         *AlertActionOutputParams `json:"params"`
-	AlertFilter    *AlertFilter             `json:"alertFilter,omitempty"`
-	Teams          *[]TeamShort             `json:"teams,omitempty"`
+	ID                      string                   `json:"id"`
+	Name                    string                   `json:"name"`
+	AlertSourceIDs          []int64                  `json:"alertSourceIds,omitempty"` // @deprecated
+	AlertSources            *[]AlertSource           `json:"alertSources,omitempty"`
+	ConnectorID             string                   `json:"connectorId"`
+	ConnectorType           string                   `json:"connectorType"`
+	TriggerMode             string                   `json:"triggerMode"`
+	DelaySec                int                      `json:"delaySec,omitempty"`                // @deprecated
+	EscalationEndedDelaySec int                      `json:"escalationEndedDelaySec,omitempty"` // between 0 and 7200, used with triggerType 'AlertEscalationEnded'
+	NotResolvedDelaySec     int                      `json:"notResolvedDelaySec,omitempty"`     // between 0 and 7200, used with triggerType 'AlertNotResolved'
+	TriggerTypes            []string                 `json:"triggerTypes,omitempty"`
+	CreatedAt               string                   `json:"createdAt"` // date time string in ISO 8601
+	UpdatedAt               string                   `json:"updatedAt"` // date time string in ISO 8601
+	Params                  *AlertActionOutputParams `json:"params"`
+	AlertFilter             *AlertFilter             `json:"alertFilter,omitempty"`
+	Teams                   *[]TeamShort             `json:"teams,omitempty"`
 }
 
 // AlertActionOutputParams definition
@@ -262,6 +266,7 @@ var AlertActionTriggerTypes = struct {
 	AlertResponderRemoved string
 	AlertChannelAttached  string
 	AlertChannelDetached  string
+	AlertNotResolved      string
 }{
 	AlertCreated:          "alert-created",
 	AlertAssigned:         "alert-assigned",
@@ -276,6 +281,7 @@ var AlertActionTriggerTypes = struct {
 	AlertResponderRemoved: "alert-responder-removed",
 	AlertChannelAttached:  "alert-channel-attached",
 	AlertChannelDetached:  "alert-channel-detached",
+	AlertNotResolved:      "v-alert-not-resolved",
 }
 
 // AlertActionTriggerTypesAll defines all alertAction trigger types
@@ -293,6 +299,7 @@ var AlertActionTriggerTypesAll = []string{
 	AlertActionTriggerTypes.AlertResponderRemoved,
 	AlertActionTriggerTypes.AlertChannelAttached,
 	AlertActionTriggerTypes.AlertChannelDetached,
+	AlertActionTriggerTypes.AlertNotResolved,
 }
 
 // AlertFilterOperator defines alertFilter operator

--- a/alert_action.go
+++ b/alert_action.go
@@ -122,6 +122,11 @@ type AlertActionParamsMicrosoftTeamsWebhook struct {
 	URL string `json:"url,omitempty"`
 }
 
+// AlertActionParamsSlackWebhook definition
+type AlertActionParamsSlackWebhook struct {
+	URL string `json:"url,omitempty"`
+}
+
 // AlertActionParamsServiceNow definition
 type AlertActionParamsServiceNow struct {
 	CallerID string `json:"callerId,omitempty"` // user email

--- a/alert_source.go
+++ b/alert_source.go
@@ -44,7 +44,7 @@ type AlertSource struct {
 	LinkTemplates          []LinkTemplate         `json:"linkTemplates,omitempty"`
 	PriorityTemplate       *PriorityTemplate      `json:"priorityTemplate,omitempty"`
 	AlertGroupingWindow    string                 `json:"alertGroupingWindow,omitempty"` // e.g. PT4H
-	ScoreThreshold         string                 `json:"scoreThreshold,omitempty"`
+	ScoreThreshold         int64                  `json:"scoreThreshold,omitempty"`
 	EventFilter            string                 `json:"eventFilter,omitempty"`
 }
 

--- a/alert_source.go
+++ b/alert_source.go
@@ -44,7 +44,7 @@ type AlertSource struct {
 	LinkTemplates          []LinkTemplate         `json:"linkTemplates,omitempty"`
 	PriorityTemplate       *PriorityTemplate      `json:"priorityTemplate,omitempty"`
 	AlertGroupingWindow    string                 `json:"alertGroupingWindow,omitempty"` // e.g. PT4H
-	ScoreThreshold         int64                  `json:"scoreThreshold,omitempty"`
+	ScoreThreshold         float64                `json:"scoreThreshold,omitempty"`
 	EventFilter            string                 `json:"eventFilter,omitempty"`
 }
 
@@ -469,6 +469,10 @@ var AlertSourceIntegrationTypesAll = []string{
 type CreateAlertSourceInput struct {
 	_           struct{}
 	AlertSource *AlertSource
+
+	// describes optional properties that should be included in the response
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "eventFilter"
+	Include []*string
 }
 
 // CreateAlertSourceOutput represents the output of a CreateAlertSource operation.
@@ -506,7 +510,13 @@ func (c *Client) CreateAlertSource(input *CreateAlertSourceInput) (*CreateAlertS
 		v.RemoveLegacyFields()
 	}
 
-	resp, err := c.httpClient.R().SetBody(input.AlertSource).Post(apiRoutes.alertSources)
+	q := url.Values{}
+
+	for _, include := range input.Include {
+		q.Add("include", *include)
+	}
+
+	resp, err := c.httpClient.R().SetBody(input.AlertSource).Post(fmt.Sprintf("%s?%s", apiRoutes.alertSources, q.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +539,7 @@ type GetAlertSourceInput struct {
 	AlertSourceID *int64
 
 	// describes optional properties that should be included in the response
-	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "textTemplate", "linkTemplates", "priorityTemplate"
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "eventFilter"
 	Include []*string
 }
 
@@ -659,6 +669,10 @@ type UpdateAlertSourceInput struct {
 	_             struct{}
 	AlertSourceID *int64
 	AlertSource   *AlertSource
+
+	// describes optional properties that should be included in the response
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "eventFilter"
+	Include []*string
 }
 
 // UpdateAlertSourceOutput represents the output of a UpdateAlertSource operation.
@@ -699,7 +713,13 @@ func (c *Client) UpdateAlertSource(input *UpdateAlertSourceInput) (*UpdateAlertS
 		v.RemoveLegacyFields()
 	}
 
-	resp, err := c.httpClient.R().SetBody(input.AlertSource).Put(fmt.Sprintf("%s/%d", apiRoutes.alertSources, *input.AlertSourceID))
+	q := url.Values{}
+
+	for _, include := range input.Include {
+		q.Add("include", *include)
+	}
+
+	resp, err := c.httpClient.R().SetBody(input.AlertSource).Put(fmt.Sprintf("%s/%d?%s", apiRoutes.alertSources, *input.AlertSourceID, q.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/alert_source.go
+++ b/alert_source.go
@@ -45,6 +45,7 @@ type AlertSource struct {
 	PriorityTemplate       *PriorityTemplate      `json:"priorityTemplate,omitempty"`
 	AlertGroupingWindow    string                 `json:"alertGroupingWindow,omitempty"` // e.g. PT4H
 	ScoreThreshold         string                 `json:"scoreThreshold,omitempty"`
+	EventFilter            string                 `json:"eventFilter,omitempty"`
 }
 
 // EmailPredicate definition

--- a/alert_source.go
+++ b/alert_source.go
@@ -44,6 +44,7 @@ type AlertSource struct {
 	LinkTemplates          []LinkTemplate         `json:"linkTemplates,omitempty"`
 	PriorityTemplate       *PriorityTemplate      `json:"priorityTemplate,omitempty"`
 	AlertGroupingWindow    string                 `json:"alertGroupingWindow,omitempty"` // e.g. PT4H
+	ScoreThreshold         string                 `json:"scoreThreshold,omitempty"`
 }
 
 // EmailPredicate definition
@@ -165,6 +166,7 @@ var AlertSourceAlertCreations = struct {
 	OneOpenAlertAllowed      string
 	OpenResolveOnExtraction  string
 	OneAlertGroupedPerWindow string
+	IntelligentGrouping      string
 }{
 	// @deprecated
 	OneIncidentPerEmail:        "ONE_INCIDENT_PER_EMAIL",
@@ -178,6 +180,7 @@ var AlertSourceAlertCreations = struct {
 	OneOpenAlertAllowed:      "ONE_OPEN_ALERT_ALLOWED",
 	OpenResolveOnExtraction:  "OPEN_RESOLVE_ON_EXTRACTION",
 	OneAlertGroupedPerWindow: "ONE_ALERT_GROUPED_PER_WINDOW",
+	IntelligentGrouping:      "INTELLIGENT_GROUPING",
 }
 
 // AlertSourceAlertCreationsAll defines alert source alert creations list
@@ -194,6 +197,7 @@ var AlertSourceAlertCreationsAll = []string{
 	AlertSourceAlertCreations.OneOpenAlertAllowed,
 	AlertSourceAlertCreations.OpenResolveOnExtraction,
 	AlertSourceAlertCreations.OneAlertGroupedPerWindow,
+	AlertSourceAlertCreations.IntelligentGrouping,
 }
 
 // AlertSourceAlertGroupingWindows defines alert source alert grouping windows

--- a/connector.go
+++ b/connector.go
@@ -155,6 +155,7 @@ var ConnectorTypes = struct {
 	MicrosoftTeamsWebhook string
 	ServiceNow            string
 	Slack                 string
+	SlackWebhook          string
 	Telegram              string
 	Topdesk               string
 	Webhook               string
@@ -175,6 +176,7 @@ var ConnectorTypes = struct {
 	MicrosoftTeamsWebhook: "microsoft_teams_webhook",
 	ServiceNow:            "servicenow",
 	Slack:                 "slack",
+	SlackWebhook:          "slack_webhook",
 	Telegram:              "telegram",
 	Topdesk:               "topdesk",
 	Webhook:               "webhook",
@@ -198,6 +200,7 @@ var ConnectorTypesAll = []string{
 	ConnectorTypes.MicrosoftTeamsWebhook,
 	ConnectorTypes.ServiceNow,
 	ConnectorTypes.Slack,
+	ConnectorTypes.SlackWebhook,
 	ConnectorTypes.Telegram,
 	ConnectorTypes.Topdesk,
 	ConnectorTypes.Webhook,

--- a/status_page.go
+++ b/status_page.go
@@ -36,6 +36,10 @@ type StatusPage struct {
 	Structure                 *StatusPageStructure `json:"structure,omitempty"`
 	ThemeMode                 string               `json:"themeMode,omitempty"` // please use field `Appearance` instead
 	Appearance                string               `json:"appearance,omitempty"`
+	EmailWhitelist            []string             `json:"emailWhitelist,omitempty"`
+	Announcement              string               `json:"announcement,omitempty"`
+	AnnouncementOnPage        bool                 `json:"announcementOnPage,omitempty"`
+	AnnouncementInWidget      bool                 `json:"announcementInWidget,omitempty"`
 }
 
 // StatusPageStructure defines status page structure

--- a/status_page.go
+++ b/status_page.go
@@ -40,6 +40,7 @@ type StatusPage struct {
 	Announcement              string               `json:"announcement,omitempty"`
 	AnnouncementOnPage        bool                 `json:"announcementOnPage,omitempty"`
 	AnnouncementInWidget      bool                 `json:"announcementInWidget,omitempty"`
+	Metrics                   []Metric             `json:"metrics,omitempty"`
 }
 
 // StatusPageStructure defines status page structure

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.8.3"
+const Version = "v3.9.0"


### PR DESCRIPTION
- add new api resources/fields pt.1
  - alert action
    - deprecate `delaySec` in favor of more specific `escalationEndedDelaySec` and `notResolvedDelaySec`
    - new trigger type `AlertNotResolved`
    - new alert action type `SlackWebhook`
  - alert source
    - new alert grouping type `intelligentGrouping`
      - add field `scoreThreshold`
    - add event filter
    - add includes for POST and PUT API calls
  - status page
    - add email login via `emailWhitelist`
    - add `announcement` fields
    - add `metrics`