### PR TITLE
Feature/alert action add remove source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 02.06.2026, Version 3.20.0
+
+- add `AddAlertSourceToAlertAction` and `RemoveAlertSourceFromAlertAction` methods for non-destructive alert-source attachment [#66](https://github.com/iLert/ilert-go/pull/66)
+
 ## 22.04.2026, Version 3.19.0
 
 - add reroute param for alert action [#65](https://github.com/iLert/ilert-go/pull/65)

--- a/alert_action.go
+++ b/alert_action.go
@@ -646,3 +646,89 @@ func (c *Client) DeleteAlertAction(input *DeleteAlertActionInput) (*DeleteAlertA
 
 	return &DeleteAlertActionOutput{}, nil
 }
+
+// AddAlertSourceToAlertActionInput represents the input of an AddAlertSourceToAlertAction operation.
+type AddAlertSourceToAlertActionInput struct {
+	_             struct{}
+	AlertActionID *string
+	AlertSourceID *int64
+}
+
+// AddAlertSourceToAlertActionOutput represents the output of an AddAlertSourceToAlertAction operation.
+type AddAlertSourceToAlertActionOutput struct {
+	_           struct{}
+	AlertAction *AlertActionOutput
+}
+
+// AddAlertSourceToAlertAction attaches an alert source to an alert action without overwriting existing sources. https://docs.ilert.com/developer-docs/rest-api/api-reference
+func (c *Client) AddAlertSourceToAlertAction(input *AddAlertSourceToAlertActionInput) (*AddAlertSourceToAlertActionOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.AlertActionID == nil {
+		return nil, errors.New("alert action id is required")
+	}
+	if input.AlertSourceID == nil {
+		return nil, errors.New("alert source id is required")
+	}
+
+	body := map[string]int64{"alertSourceId": *input.AlertSourceID}
+	resp, err := c.httpClient.R().SetBody(body).Put(fmt.Sprintf("%s/%s/add-source", apiRoutes.alertActions, *input.AlertActionID))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	alertAction := &AlertActionOutput{}
+	err = json.Unmarshal(resp.Body(), alertAction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AddAlertSourceToAlertActionOutput{AlertAction: alertAction}, nil
+}
+
+// RemoveAlertSourceFromAlertActionInput represents the input of a RemoveAlertSourceFromAlertAction operation.
+type RemoveAlertSourceFromAlertActionInput struct {
+	_             struct{}
+	AlertActionID *string
+	AlertSourceID *int64
+}
+
+// RemoveAlertSourceFromAlertActionOutput represents the output of a RemoveAlertSourceFromAlertAction operation.
+type RemoveAlertSourceFromAlertActionOutput struct {
+	_           struct{}
+	AlertAction *AlertActionOutput
+}
+
+// RemoveAlertSourceFromAlertAction detaches an alert source from an alert action without affecting other sources. https://docs.ilert.com/developer-docs/rest-api/api-reference
+func (c *Client) RemoveAlertSourceFromAlertAction(input *RemoveAlertSourceFromAlertActionInput) (*RemoveAlertSourceFromAlertActionOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is required")
+	}
+	if input.AlertActionID == nil {
+		return nil, errors.New("alert action id is required")
+	}
+	if input.AlertSourceID == nil {
+		return nil, errors.New("alert source id is required")
+	}
+
+	body := map[string]int64{"alertSourceId": *input.AlertSourceID}
+	resp, err := c.httpClient.R().SetBody(body).Put(fmt.Sprintf("%s/%s/remove-source", apiRoutes.alertActions, *input.AlertActionID))
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := getGenericAPIError(resp, 200); apiErr != nil {
+		return nil, apiErr
+	}
+
+	alertAction := &AlertActionOutput{}
+	err = json.Unmarshal(resp.Body(), alertAction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RemoveAlertSourceFromAlertActionOutput{AlertAction: alertAction}, nil
+}

--- a/examples/alert_action/main.go
+++ b/examples/alert_action/main.go
@@ -70,4 +70,24 @@ func main() {
 		log.Fatalln("ERROR:", err)
 	}
 	log.Printf("New alert action is created:\n%+v\n", *rcn.AlertAction)
+
+	radd, err := client.AddAlertSourceToAlertAction(&ilert.AddAlertSourceToAlertActionInput{
+		AlertActionID: ilert.String(rcn.AlertAction.ID),
+		AlertSourceID: ilert.Int64(ras.AlertSource.ID),
+	})
+	if err != nil {
+		log.Println(radd)
+		log.Fatalln("ERROR:", err)
+	}
+	log.Printf("Alert source added to alert action:\n%+v\n", *radd.AlertAction)
+
+	rrem, err := client.RemoveAlertSourceFromAlertAction(&ilert.RemoveAlertSourceFromAlertActionInput{
+		AlertActionID: ilert.String(rcn.AlertAction.ID),
+		AlertSourceID: ilert.Int64(ras.AlertSource.ID),
+	})
+	if err != nil {
+		log.Println(rrem)
+		log.Fatalln("ERROR:", err)
+	}
+	log.Printf("Alert source removed from alert action:\n%+v\n", *rrem.AlertAction)
 }

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.19.0"
+const Version = "v3.20.0"


### PR DESCRIPTION
- add `AddAlertSourceToAlertAction` and `RemoveAlertSourceFromAlertAction` methods for non-destructive single-source attach/detach
- add example + manually tested add-source/remove-source against live API