### PR TITLE
Feature/alert source dynamic services mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 08.06.2026, Version 3.22.0
+
+- add `servicesTemplate` (dynamic services mapping), default `services` and `autoCreateServices` to alert source [#70](https://github.com/iLert/ilert-go/pull/70)
+
 ## 05.06.2026, Version 3.21.0
 
 - add event flow integration CRUD [#67](https://github.com/iLert/ilert-go/pull/67)

--- a/alert_source.go
+++ b/alert_source.go
@@ -47,6 +47,9 @@ type AlertSource struct {
 	PriorityTemplate       *PriorityTemplate      `json:"priorityTemplate,omitempty"`
 	SeverityTemplate       *SeverityTemplate      `json:"severityTemplate,omitempty"`
 	Severity               int                    `json:"severity,omitempty"`
+	Services               []AlertSourceService   `json:"services,omitempty"`            // default services attached to created alerts
+	ServicesTemplate       []Template             `json:"servicesTemplate,omitempty"`    // dynamic services mapping, extracts service identifiers from the event payload
+	AutoCreateServices     bool                   `json:"autoCreateServices"`            // not omitempty: an explicit false must be sent to disable auto-creation
 	AlertGroupingWindow    string                 `json:"alertGroupingWindow,omitempty"` // e.g. PT4H
 	ScoreThreshold         float64                `json:"scoreThreshold,omitempty"`
 	EventFilter            string                 `json:"eventFilter,omitempty"`
@@ -146,6 +149,12 @@ type SeverityTemplate struct {
 type SeverityMapping struct {
 	Value    string `json:"value"`
 	Severity int    `json:"severity"`
+}
+
+// AlertSourceService defines a shallow service reference used for default services on an alert source
+type AlertSourceService struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name,omitempty"`
 }
 
 // AlertSourceStatuses defines alert source statuses
@@ -706,7 +715,7 @@ type CreateAlertSourceInput struct {
 	AlertSource *AlertSource
 
 	// describes optional properties that should be included in the response
-	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "servicesTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
 	Include []*string
 }
 
@@ -774,7 +783,7 @@ type GetAlertSourceInput struct {
 	AlertSourceID *int64
 
 	// describes optional properties that should be included in the response
-	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "servicesTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
 	Include []*string
 }
 
@@ -906,7 +915,7 @@ type UpdateAlertSourceInput struct {
 	AlertSource   *AlertSource
 
 	// describes optional properties that should be included in the response
-	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
+	// possible values: "summaryTemplate", "detailsTemplate", "routingTemplate", "alertKeyTemplate", "textTemplate", "linkTemplates", "priorityTemplate", "severityTemplate", "servicesTemplate", "eventFilter", "eventTypeFilterCreate", "eventTypeFilterAccept", "eventTypeFilterResolve"
 	Include []*string
 }
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.21.0"
+const Version = "v3.22.0"


### PR DESCRIPTION
- add `AlertSourceService` type and `services`/`servicesTemplate`/`autoCreateServices` fields to alert source for default services and dynamic services mapping