### PR TITLE
Feature/add documented api fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 20.07.2026, Version 3.23.0
+## 22.07.2026, Version 3.23.0
 
 - **Source-compatibility note:** the output `CompanyID` field on `AlertActionOutputParams` and `ConnectionOutputParams` changes type from `int64` to `string` (see the Autotask fix below). This is source-breaking for code referencing those fields as `int64`, but it ships in a minor release because the fields never unmarshalled successfully before, so no working caller could depend on the `int64` form. [#73](https://github.com/iLert/ilert-go/pull/73)
 - add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
+- add `VIEWER` to `UserRole` and `TeamMemberRoles` [#73](https://github.com/iLert/ilert-go/pull/73)
 - fix reading Autotask alert actions and connections: `companyId`/`queueId` are returned by the API as JSON strings and previously failed to unmarshal; `queueId` now tolerates both encodings, and the output `companyId` is typed `string` to match its API contract and the create/update params (it never unmarshalled successfully before) [#73](https://github.com/iLert/ilert-go/pull/73)
 
 ## 08.06.2026, Version 3.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 20.07.2026, Version 3.23.0
 
+- **Source-compatibility note:** the output `CompanyID` field on `AlertActionOutputParams` and `ConnectionOutputParams` changes type from `int64` to `string` (see the Autotask fix below). This is source-breaking for code referencing those fields as `int64`, but it ships in a minor release because the fields never unmarshalled successfully before, so no working caller could depend on the `int64` form. [#73](https://github.com/iLert/ilert-go/pull/73)
 - add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
 - fix reading Autotask alert actions and connections: `companyId`/`queueId` are returned by the API as JSON strings and previously failed to unmarshal; `queueId` now tolerates both encodings, and the output `companyId` is typed `string` to match its API contract and the create/update params (it never unmarshalled successfully before) [#73](https://github.com/iLert/ilert-go/pull/73)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 20.07.2026, Version 3.23.0
 
 - add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
-- fix Autotask `companyId`/`queueId` unmarshal by typing them as `string` on `AlertActionOutputParams` (the API returns them as strings) [#73](https://github.com/iLert/ilert-go/pull/73)
+- fix Autotask `companyId`/`queueId` unmarshal by typing them as `string` on the alert action and connection output params (the API returns them as strings) [#73](https://github.com/iLert/ilert-go/pull/73)
 
 ## 08.06.2026, Version 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 20.07.2026, Version 3.23.0
 
 - add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
-- fix reading Autotask alert actions and connections: tolerate `companyId`/`queueId` being returned as JSON strings (they previously failed to unmarshal into the int64 fields) [#73](https://github.com/iLert/ilert-go/pull/73)
+- fix reading Autotask alert actions and connections: `companyId`/`queueId` are returned by the API as JSON strings and previously failed to unmarshal; `queueId` now tolerates both encodings, and the output `companyId` is typed `string` to match its API contract and the create/update params (it never unmarshalled successfully before) [#73](https://github.com/iLert/ilert-go/pull/73)
 
 ## 08.06.2026, Version 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.07.2026, Version 3.23.0
+
+- add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
+- fix Autotask `companyId`/`queueId` unmarshal by typing them as `string` on `AlertActionOutputParams` (the API returns them as strings) [#73](https://github.com/iLert/ilert-go/pull/73)
+
 ## 08.06.2026, Version 3.22.0
 
 - add `servicesTemplate` (dynamic services mapping), default `services` and `autoCreateServices` to alert source [#70](https://github.com/iLert/ilert-go/pull/70)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 20.07.2026, Version 3.23.0
 
 - add documented ServiceNow (`closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering`, `contactType`) and Autotask (`noteType`, `notePublish`, `status`) alert action params, service `alias` and call flow VOICEMAIL `disableTranscription` [#73](https://github.com/iLert/ilert-go/pull/73)
-- fix Autotask `companyId`/`queueId` unmarshal by typing them as `string` on the alert action and connection output params (the API returns them as strings) [#73](https://github.com/iLert/ilert-go/pull/73)
+- fix reading Autotask alert actions and connections: tolerate `companyId`/`queueId` being returned as JSON strings (they previously failed to unmarshal into the int64 fields) [#73](https://github.com/iLert/ilert-go/pull/73)
 
 ## 08.06.2026, Version 3.22.0
 

--- a/alert_action.go
+++ b/alert_action.go
@@ -58,7 +58,7 @@ type AlertActionOutputParams struct {
 	CallerID           string                           `json:"callerId,omitempty"`           // ServiceNow: user email
 	ChannelID          string                           `json:"channelId,omitempty"`          // Slack, Telegram
 	ChannelName        string                           `json:"channelName,omitempty"`        // Slack
-	CompanyID          int64                            `json:"companyId,omitempty"`          // Autotask: Company ID
+	CompanyID          string                           `json:"companyId,omitempty"`          // Autotask: Company ID (API returns as string)
 	Email              string                           `json:"email,omitempty"`              // Zammad
 	EventFilter        string                           `json:"eventFilter,omitempty"`        // Sysdig
 	Impact             string                           `json:"impact,omitempty"`             // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
@@ -71,7 +71,7 @@ type AlertActionOutputParams struct {
 	PageID             string                           `json:"pageId,omitempty"`             // StatusPage.io
 	Priority           string                           `json:"priority,omitempty"`           // Datadog: "normal" | "low". Zendesk: "urgent" | "high" | "normal" | "low".
 	Project            string                           `json:"project,omitempty"`            // Jira
-	QueueID            int64                            `json:"queueId,omitempty"`            // Autotask: Queue ID
+	QueueID            string                           `json:"queueId,omitempty"`            // Autotask: Queue ID (API returns as string)
 	Recipients         []string                         `json:"recipients,omitempty"`         // Email
 	Repository         string                           `json:"repository,omitempty"`         // Github
 	ResolveIncident    bool                             `json:"resolveIncident,omitempty"`    // Automation rule

--- a/alert_action.go
+++ b/alert_action.go
@@ -58,7 +58,7 @@ type AlertActionOutputParams struct {
 	CallerID           string                           `json:"callerId,omitempty"`           // ServiceNow: user email
 	ChannelID          string                           `json:"channelId,omitempty"`          // Slack, Telegram
 	ChannelName        string                           `json:"channelName,omitempty"`        // Slack
-	CompanyID          int64                            `json:"companyId,omitempty"`          // Autotask: Company ID
+	CompanyID          string                           `json:"companyId,omitempty"`          // Autotask: Company ID
 	Email              string                           `json:"email,omitempty"`              // Zammad
 	EventFilter        string                           `json:"eventFilter,omitempty"`        // Sysdig
 	Impact             string                           `json:"impact,omitempty"`             // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
@@ -105,21 +105,58 @@ type AlertActionOutputParams struct {
 	NotePublish        string                           `json:"notePublish,omitempty"`        // Autotask
 }
 
+// flexInt64 parses a JSON value that may be a number ("8"), a numeric string
+// ("8") or absent into an int64. Empty, missing or non-numeric values (e.g. "")
+// decode to 0 rather than failing the surrounding unmarshal.
+func flexInt64(raw json.RawMessage) int64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var n int64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		i, _ := strconv.ParseInt(s, 10, 64)
+		return i
+	}
+	return 0
+}
+
+// flexString parses a JSON value that may be a string ("12345") or a number
+// (12345) into a string. Missing values decode to "" rather than failing the
+// surrounding unmarshal.
+func flexString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n.String()
+	}
+	return ""
+}
+
 // UnmarshalJSON tolerates the Autotask companyId/queueId fields being returned
-// as JSON strings (the API serializes them as strings) while keeping the struct
-// fields as int64 for backwards compatibility.
+// as either JSON strings (the API serializes them as strings) or numbers.
+// CompanyID is kept as a string (its API contract), QueueID as an int64.
 func (p *AlertActionOutputParams) UnmarshalJSON(data []byte) error {
 	type alias AlertActionOutputParams
 	aux := struct {
-		CompanyID json.Number `json:"companyId,omitempty"`
-		QueueID   json.Number `json:"queueId,omitempty"`
+		CompanyID json.RawMessage `json:"companyId,omitempty"`
+		QueueID   json.RawMessage `json:"queueId,omitempty"`
 		*alias
 	}{alias: (*alias)(p)}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	p.CompanyID, _ = aux.CompanyID.Int64()
-	p.QueueID, _ = aux.QueueID.Int64()
+	p.CompanyID = flexString(aux.CompanyID)
+	p.QueueID = flexInt64(aux.QueueID)
 	return nil
 }
 

--- a/alert_action.go
+++ b/alert_action.go
@@ -58,7 +58,7 @@ type AlertActionOutputParams struct {
 	CallerID           string                           `json:"callerId,omitempty"`           // ServiceNow: user email
 	ChannelID          string                           `json:"channelId,omitempty"`          // Slack, Telegram
 	ChannelName        string                           `json:"channelName,omitempty"`        // Slack
-	CompanyID          string                           `json:"companyId,omitempty"`          // Autotask: Company ID (API returns as string)
+	CompanyID          int64                            `json:"companyId,omitempty"`          // Autotask: Company ID
 	Email              string                           `json:"email,omitempty"`              // Zammad
 	EventFilter        string                           `json:"eventFilter,omitempty"`        // Sysdig
 	Impact             string                           `json:"impact,omitempty"`             // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
@@ -71,7 +71,7 @@ type AlertActionOutputParams struct {
 	PageID             string                           `json:"pageId,omitempty"`             // StatusPage.io
 	Priority           string                           `json:"priority,omitempty"`           // Datadog: "normal" | "low". Zendesk: "urgent" | "high" | "normal" | "low".
 	Project            string                           `json:"project,omitempty"`            // Jira
-	QueueID            string                           `json:"queueId,omitempty"`            // Autotask: Queue ID (API returns as string)
+	QueueID            int64                            `json:"queueId,omitempty"`            // Autotask: Queue ID
 	Recipients         []string                         `json:"recipients,omitempty"`         // Email
 	Repository         string                           `json:"repository,omitempty"`         // Github
 	ResolveIncident    bool                             `json:"resolveIncident,omitempty"`    // Automation rule
@@ -103,6 +103,24 @@ type AlertActionOutputParams struct {
 	ContactType        string                           `json:"contactType,omitempty"`        // ServiceNow
 	NoteType           string                           `json:"noteType,omitempty"`           // Autotask
 	NotePublish        string                           `json:"notePublish,omitempty"`        // Autotask
+}
+
+// UnmarshalJSON tolerates the Autotask companyId/queueId fields being returned
+// as JSON strings (the API serializes them as strings) while keeping the struct
+// fields as int64 for backwards compatibility.
+func (p *AlertActionOutputParams) UnmarshalJSON(data []byte) error {
+	type alias AlertActionOutputParams
+	aux := struct {
+		CompanyID json.Number `json:"companyId,omitempty"`
+		QueueID   json.Number `json:"queueId,omitempty"`
+		*alias
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	p.CompanyID, _ = aux.CompanyID.Int64()
+	p.QueueID, _ = aux.QueueID.Int64()
+	return nil
 }
 
 // AlertActionParamsAutotask definition

--- a/alert_action.go
+++ b/alert_action.go
@@ -95,6 +95,14 @@ type AlertActionOutputParams struct {
 	Headers            []AlertActionParamsWebhookHeader `json:"headers,omitempty"`            // Custom
 	URL                string                           `json:"url,omitempty"`                // DingTalk
 	EscalationPolicyID int64                            `json:"escalationPolicyId,omitempty"` // Reroute
+	CloseCode          string                           `json:"closeCode,omitempty"`          // ServiceNow
+	AssignmentGroup    string                           `json:"assignmentGroup,omitempty"`    // ServiceNow
+	OwnerGroup         string                           `json:"ownerGroup,omitempty"`         // ServiceNow
+	Service            string                           `json:"service,omitempty"`            // ServiceNow
+	ServiceOffering    string                           `json:"serviceOffering,omitempty"`    // ServiceNow
+	ContactType        string                           `json:"contactType,omitempty"`        // ServiceNow
+	NoteType           string                           `json:"noteType,omitempty"`           // Autotask
+	NotePublish        string                           `json:"notePublish,omitempty"`        // Autotask
 }
 
 // AlertActionParamsAutotask definition
@@ -104,6 +112,9 @@ type AlertActionParamsAutotask struct {
 	QueueID        int64  `json:"queueId,omitempty"`        // Autotask: Queue ID
 	TicketCategory string `json:"ticketCategory,omitempty"` // Autotask ticket category
 	TicketType     string `json:"ticketType,omitempty"`     // Autotask ticket type
+	NoteType       string `json:"noteType,omitempty"`       // Autotask note type
+	NotePublish    string `json:"notePublish,omitempty"`    // Autotask note publish
+	Status         string `json:"status,omitempty"`         // Autotask ticket status
 }
 
 // AlertActionParamsJira definition
@@ -138,10 +149,16 @@ type AlertActionParamsSlackWebhook struct {
 
 // AlertActionParamsServiceNow definition
 type AlertActionParamsServiceNow struct {
-	CallerID     string `json:"callerId,omitempty"` // user email
-	Impact       string `json:"impact,omitempty"`   // 1 - High, 2 - Medium, 3 - Low (Default)
-	Urgency      string `json:"urgency,omitempty"`  // 1 - High, 2 - Medium, 3 - Low (Default)
-	BodyTemplate string `json:"bodyTemplate,omitempty"`
+	CallerID        string `json:"callerId,omitempty"` // user email
+	Impact          string `json:"impact,omitempty"`   // 1 - High, 2 - Medium, 3 - Low (Default)
+	Urgency         string `json:"urgency,omitempty"`  // 1 - High, 2 - Medium, 3 - Low (Default)
+	BodyTemplate    string `json:"bodyTemplate,omitempty"`
+	CloseCode       string `json:"closeCode,omitempty"`       // ServiceNow close code
+	AssignmentGroup string `json:"assignmentGroup,omitempty"` // ServiceNow assignment group
+	OwnerGroup      string `json:"ownerGroup,omitempty"`      // ServiceNow owner group
+	Service         string `json:"service,omitempty"`         // ServiceNow service
+	ServiceOffering string `json:"serviceOffering,omitempty"` // ServiceNow service offering
+	ContactType     string `json:"contactType,omitempty"`     // ServiceNow contact type
 }
 
 // AlertActionParamsSlack definition

--- a/alert_action_test.go
+++ b/alert_action_test.go
@@ -1,0 +1,42 @@
+package ilert
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAlertActionOutputParamsUnmarshalAutotaskIDs verifies that the Autotask
+// companyId/queueId fields decode into the int64 struct fields whether the API
+// returns them as JSON strings (which it does) or numbers, and that sibling
+// fields keep decoding through the custom UnmarshalJSON. See
+// iLert/engineering-tasks#2265.
+func TestAlertActionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		company int64
+		queue   int64
+	}{
+		{"string values", `{"companyId":"12345","queueId":"8","noteType":"1"}`, 12345, 8},
+		{"number values", `{"companyId":12345,"queueId":8,"noteType":"1"}`, 12345, 8},
+		{"missing", `{"noteType":"1"}`, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p AlertActionOutputParams
+			if err := json.Unmarshal([]byte(tc.payload), &p); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.CompanyID != tc.company {
+				t.Errorf("CompanyID = %d, want %d", p.CompanyID, tc.company)
+			}
+			if p.QueueID != tc.queue {
+				t.Errorf("QueueID = %d, want %d", p.QueueID, tc.queue)
+			}
+			// sibling fields must still decode through the custom UnmarshalJSON
+			if p.NoteType != "1" {
+				t.Errorf("NoteType = %q, want %q", p.NoteType, "1")
+			}
+		})
+	}
+}

--- a/alert_action_test.go
+++ b/alert_action_test.go
@@ -14,12 +14,14 @@ func TestAlertActionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
 	cases := []struct {
 		name    string
 		payload string
-		company int64
+		company string
 		queue   int64
 	}{
-		{"string values", `{"companyId":"12345","queueId":"8","noteType":"1"}`, 12345, 8},
-		{"number values", `{"companyId":12345,"queueId":8,"noteType":"1"}`, 12345, 8},
-		{"missing", `{"noteType":"1"}`, 0, 0},
+		{"string values", `{"companyId":"12345","queueId":"8","noteType":"1"}`, "12345", 8},
+		{"number values", `{"companyId":12345,"queueId":8,"noteType":"1"}`, "12345", 8},
+		{"missing", `{"noteType":"1"}`, "", 0},
+		{"empty string", `{"companyId":"","queueId":"","noteType":"1"}`, "", 0},
+		{"non-numeric company preserved", `{"companyId":"ACME-42","queueId":"8","noteType":"1"}`, "ACME-42", 8},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -28,7 +30,7 @@ func TestAlertActionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if p.CompanyID != tc.company {
-				t.Errorf("CompanyID = %d, want %d", p.CompanyID, tc.company)
+				t.Errorf("CompanyID = %q, want %q", p.CompanyID, tc.company)
 			}
 			if p.QueueID != tc.queue {
 				t.Errorf("QueueID = %d, want %d", p.QueueID, tc.queue)

--- a/call_flow.go
+++ b/call_flow.go
@@ -63,26 +63,27 @@ type PhoneNumber struct {
 }
 
 type CallFlowNodeMetadata struct {
-	TextMessage         string                           `json:"textMessage,omitempty"`         // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE
-	CustomAudioUrl      string                           `json:"customAudioUrl,omitempty"`      // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE
-	AIVoiceModel        string                           `json:"aiVoiceModel,omitempty"`        // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE, one of CallFlowNodeMetadataAIVoiceModel
-	EnabledOptions      []string                         `json:"enabledOptions,omitempty"`      // IVR_MENU
-	Language            string                           `json:"language,omitempty"`            // IVR_MENU or AUDIO_MESSAGE, one of CallFlowNodeMetadataLanguage
-	VarKey              string                           `json:"varKey,omitempty"`              // PLAIN
-	VarValue            string                           `json:"varValue,omitempty"`            // PLAIN
-	Codes               []CallFlowNodeMetadataCode       `json:"codes,omitempty"`               // PIN_CODE
-	SupportHoursId      int64                            `json:"supportHoursId,omitempty"`      // SUPPORT_HOURS
-	HoldAudioUrl        string                           `json:"holdAudioUrl,omitempty"`        // ROUTE_CALL
-	Targets             []CallFlowNodeMetadataCallTarget `json:"targets,omitempty"`             // ROUTE_CALL
-	CallStyle           string                           `json:"callStyle,omitempty"`           // ROUTE_CALL, one of CallFlowNodeMetadataCallStyle
-	AlertSourceId       int64                            `json:"alertSourceId,omitempty"`       // CREATE_ALERT
-	AcceptAlertOnAnswer bool                             `json:"acceptAlertOnAnswer,omitempty"` // CREATE_ALERT
-	Retries             int64                            `json:"retries,omitempty"`             // IVR_MENU or PIN_CODE or ROUTE_CALL
-	CallTimeoutSec      int64                            `json:"callTimeoutSec,omitempty"`      // ROUTE_CALL
-	Blacklist           []string                         `json:"blacklist,omitempty"`           // BLOCK_NUMBERS
-	Intents             []CallFlowNodeMetadataIntent     `json:"intents,omitempty"`             // AGENTIC
-	Gathers             []CallFlowNodeMetadataGather     `json:"gathers,omitempty"`             // AGENTIC
-	Enrichment          *CallFlowNodeMetadataEnrichment  `json:"enrichment,omitempty"`          // AGENTIC
+	TextMessage          string                           `json:"textMessage,omitempty"`          // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE
+	CustomAudioUrl       string                           `json:"customAudioUrl,omitempty"`       // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE
+	AIVoiceModel         string                           `json:"aiVoiceModel,omitempty"`         // IVR_MENU or AUDIO_MESSAGE or VOICEMAIL or PIN_CODE, one of CallFlowNodeMetadataAIVoiceModel
+	EnabledOptions       []string                         `json:"enabledOptions,omitempty"`       // IVR_MENU
+	Language             string                           `json:"language,omitempty"`             // IVR_MENU or AUDIO_MESSAGE, one of CallFlowNodeMetadataLanguage
+	VarKey               string                           `json:"varKey,omitempty"`               // PLAIN
+	VarValue             string                           `json:"varValue,omitempty"`             // PLAIN
+	Codes                []CallFlowNodeMetadataCode       `json:"codes,omitempty"`                // PIN_CODE
+	SupportHoursId       int64                            `json:"supportHoursId,omitempty"`       // SUPPORT_HOURS
+	HoldAudioUrl         string                           `json:"holdAudioUrl,omitempty"`         // ROUTE_CALL
+	Targets              []CallFlowNodeMetadataCallTarget `json:"targets,omitempty"`              // ROUTE_CALL
+	CallStyle            string                           `json:"callStyle,omitempty"`            // ROUTE_CALL, one of CallFlowNodeMetadataCallStyle
+	AlertSourceId        int64                            `json:"alertSourceId,omitempty"`        // CREATE_ALERT
+	AcceptAlertOnAnswer  bool                             `json:"acceptAlertOnAnswer,omitempty"`  // CREATE_ALERT
+	Retries              int64                            `json:"retries,omitempty"`              // IVR_MENU or PIN_CODE or ROUTE_CALL
+	CallTimeoutSec       int64                            `json:"callTimeoutSec,omitempty"`       // ROUTE_CALL
+	Blacklist            []string                         `json:"blacklist,omitempty"`            // BLOCK_NUMBERS
+	Intents              []CallFlowNodeMetadataIntent     `json:"intents,omitempty"`              // AGENTIC
+	Gathers              []CallFlowNodeMetadataGather     `json:"gathers,omitempty"`              // AGENTIC
+	Enrichment           *CallFlowNodeMetadataEnrichment  `json:"enrichment,omitempty"`           // AGENTIC
+	DisableTranscription bool                             `json:"disableTranscription,omitempty"` // VOICEMAIL
 }
 
 type CallFlowNodeMetadataCode struct {

--- a/connection.go
+++ b/connection.go
@@ -40,7 +40,7 @@ type ConnectionOutputParams struct {
 	CallerID        string   `json:"callerId,omitempty"`        // ServiceNow: user email
 	ChannelID       string   `json:"channelId,omitempty"`       // Slack
 	ChannelName     string   `json:"channelName,omitempty"`     // Slack
-	CompanyID       int64    `json:"companyId,omitempty"`       // Autotask: Company ID
+	CompanyID       string   `json:"companyId,omitempty"`       // Autotask: Company ID
 	EventFilter     string   `json:"eventFilter,omitempty"`     // Sysdig
 	Impact          string   `json:"impact,omitempty"`          // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
 	IssueType       string   `json:"issueType,omitempty"`       // Jira: "Bug" | "Epic" | "Subtask" | "Story" | "Task"
@@ -69,20 +69,20 @@ type ConnectionOutputParams struct {
 }
 
 // UnmarshalJSON tolerates the Autotask companyId/queueId fields being returned
-// as JSON strings (the API serializes them as strings) while keeping the struct
-// fields as int64 for backwards compatibility.
+// as either JSON strings (the API serializes them as strings) or numbers.
+// CompanyID is kept as a string (its API contract), QueueID as an int64.
 func (p *ConnectionOutputParams) UnmarshalJSON(data []byte) error {
 	type alias ConnectionOutputParams
 	aux := struct {
-		CompanyID json.Number `json:"companyId,omitempty"`
-		QueueID   json.Number `json:"queueId,omitempty"`
+		CompanyID json.RawMessage `json:"companyId,omitempty"`
+		QueueID   json.RawMessage `json:"queueId,omitempty"`
 		*alias
 	}{alias: (*alias)(p)}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	p.CompanyID, _ = aux.CompanyID.Int64()
-	p.QueueID, _ = aux.QueueID.Int64()
+	p.CompanyID = flexString(aux.CompanyID)
+	p.QueueID = flexInt64(aux.QueueID)
 	return nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -40,7 +40,7 @@ type ConnectionOutputParams struct {
 	CallerID        string   `json:"callerId,omitempty"`        // ServiceNow: user email
 	ChannelID       string   `json:"channelId,omitempty"`       // Slack
 	ChannelName     string   `json:"channelName,omitempty"`     // Slack
-	CompanyID       int64    `json:"companyId,omitempty"`       // Autotask: Company ID
+	CompanyID       string   `json:"companyId,omitempty"`       // Autotask: Company ID (API returns as string)
 	EventFilter     string   `json:"eventFilter,omitempty"`     // Sysdig
 	Impact          string   `json:"impact,omitempty"`          // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
 	IssueType       string   `json:"issueType,omitempty"`       // Jira: "Bug" | "Epic" | "Subtask" | "Story" | "Task"
@@ -50,7 +50,7 @@ type ConnectionOutputParams struct {
 	Owner           string   `json:"owner,omitempty"`           // Github
 	Priority        string   `json:"priority,omitempty"`        // Datadog: "normal" | "low". Zendesk: "urgent" | "high" | "normal" | "low".
 	Project         string   `json:"project,omitempty"`         // Jira
-	QueueID         int64    `json:"queueId,omitempty"`         // Autotask: Queue ID
+	QueueID         string   `json:"queueId,omitempty"`         // Autotask: Queue ID (API returns as string)
 	Recipients      []string `json:"recipients,omitempty"`      // Email
 	Repository      string   `json:"repository,omitempty"`      // Github
 	Site            string   `json:"site,omitempty"`            // Datadog: default `US`. Values: `US` or `EU`

--- a/connection.go
+++ b/connection.go
@@ -40,7 +40,7 @@ type ConnectionOutputParams struct {
 	CallerID        string   `json:"callerId,omitempty"`        // ServiceNow: user email
 	ChannelID       string   `json:"channelId,omitempty"`       // Slack
 	ChannelName     string   `json:"channelName,omitempty"`     // Slack
-	CompanyID       string   `json:"companyId,omitempty"`       // Autotask: Company ID (API returns as string)
+	CompanyID       int64    `json:"companyId,omitempty"`       // Autotask: Company ID
 	EventFilter     string   `json:"eventFilter,omitempty"`     // Sysdig
 	Impact          string   `json:"impact,omitempty"`          // ServiceNow: 1 - High, 2 - Medium, 3 - Low (Default)
 	IssueType       string   `json:"issueType,omitempty"`       // Jira: "Bug" | "Epic" | "Subtask" | "Story" | "Task"
@@ -50,7 +50,7 @@ type ConnectionOutputParams struct {
 	Owner           string   `json:"owner,omitempty"`           // Github
 	Priority        string   `json:"priority,omitempty"`        // Datadog: "normal" | "low". Zendesk: "urgent" | "high" | "normal" | "low".
 	Project         string   `json:"project,omitempty"`         // Jira
-	QueueID         string   `json:"queueId,omitempty"`         // Autotask: Queue ID (API returns as string)
+	QueueID         int64    `json:"queueId,omitempty"`         // Autotask: Queue ID
 	Recipients      []string `json:"recipients,omitempty"`      // Email
 	Repository      string   `json:"repository,omitempty"`      // Github
 	Site            string   `json:"site,omitempty"`            // Datadog: default `US`. Values: `US` or `EU`
@@ -66,6 +66,24 @@ type ConnectionOutputParams struct {
 	Email           string   `json:"email,omitempty"`           // Zammad
 	PageID          string   `json:"pageId,omitempty"`          // StatusPage.io
 	URL             string   `json:"url,omitempty"`             // DingTalk
+}
+
+// UnmarshalJSON tolerates the Autotask companyId/queueId fields being returned
+// as JSON strings (the API serializes them as strings) while keeping the struct
+// fields as int64 for backwards compatibility.
+func (p *ConnectionOutputParams) UnmarshalJSON(data []byte) error {
+	type alias ConnectionOutputParams
+	aux := struct {
+		CompanyID json.Number `json:"companyId,omitempty"`
+		QueueID   json.Number `json:"queueId,omitempty"`
+		*alias
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	p.CompanyID, _ = aux.CompanyID.Int64()
+	p.QueueID, _ = aux.QueueID.Int64()
+	return nil
 }
 
 // ConnectionParamsAutotask definition

--- a/connection_test.go
+++ b/connection_test.go
@@ -13,12 +13,14 @@ func TestConnectionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
 	cases := []struct {
 		name    string
 		payload string
-		company int64
+		company string
 		queue   int64
 	}{
-		{"string values", `{"companyId":"12345","queueId":"8","ticketType":"t"}`, 12345, 8},
-		{"number values", `{"companyId":12345,"queueId":8,"ticketType":"t"}`, 12345, 8},
-		{"missing", `{"ticketType":"t"}`, 0, 0},
+		{"string values", `{"companyId":"12345","queueId":"8","ticketType":"t"}`, "12345", 8},
+		{"number values", `{"companyId":12345,"queueId":8,"ticketType":"t"}`, "12345", 8},
+		{"missing", `{"ticketType":"t"}`, "", 0},
+		{"empty string", `{"companyId":"","queueId":"","ticketType":"t"}`, "", 0},
+		{"non-numeric company preserved", `{"companyId":"ACME-42","queueId":"8","ticketType":"t"}`, "ACME-42", 8},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -27,7 +29,7 @@ func TestConnectionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if p.CompanyID != tc.company {
-				t.Errorf("CompanyID = %d, want %d", p.CompanyID, tc.company)
+				t.Errorf("CompanyID = %q, want %q", p.CompanyID, tc.company)
 			}
 			if p.QueueID != tc.queue {
 				t.Errorf("QueueID = %d, want %d", p.QueueID, tc.queue)

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,40 @@
+package ilert
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestConnectionOutputParamsUnmarshalAutotaskIDs verifies that the legacy
+// connection params decode Autotask companyId/queueId into their int64 fields
+// whether the API returns them as JSON strings (which it does) or numbers, and
+// that sibling fields keep decoding through the custom UnmarshalJSON.
+func TestConnectionOutputParamsUnmarshalAutotaskIDs(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		company int64
+		queue   int64
+	}{
+		{"string values", `{"companyId":"12345","queueId":"8","ticketType":"t"}`, 12345, 8},
+		{"number values", `{"companyId":12345,"queueId":8,"ticketType":"t"}`, 12345, 8},
+		{"missing", `{"ticketType":"t"}`, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p ConnectionOutputParams
+			if err := json.Unmarshal([]byte(tc.payload), &p); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.CompanyID != tc.company {
+				t.Errorf("CompanyID = %d, want %d", p.CompanyID, tc.company)
+			}
+			if p.QueueID != tc.queue {
+				t.Errorf("QueueID = %d, want %d", p.QueueID, tc.queue)
+			}
+			if p.TicketType != "t" {
+				t.Errorf("TicketType = %q, want %q", p.TicketType, "t")
+			}
+		})
+	}
+}

--- a/service.go
+++ b/service.go
@@ -12,6 +12,7 @@ import (
 type Service struct {
 	ID                  int64          `json:"id"`
 	Name                string         `json:"name"`
+	Alias               string         `json:"alias,omitempty"`
 	Status              string         `json:"status"`
 	Description         string         `json:"description"`
 	OneOpenIncidentOnly bool           `json:"oneOpenIncidentOnly"`

--- a/team.go
+++ b/team.go
@@ -19,7 +19,7 @@ type Team struct {
 // TeamMember definition
 type TeamMember struct {
 	User User   `json:"user"`
-	Role string `json:"role"` // "ADMIN" or "USER" or "RESPONDER" or "STAKEHOLDER"
+	Role string `json:"role"` // "ADMIN" or "USER" or "RESPONDER" or "STAKEHOLDER" or "VIEWER"
 }
 
 // TeamShort definition
@@ -34,11 +34,13 @@ var TeamMemberRoles = struct {
 	User        string
 	Responder   string
 	Stakeholder string
+	Viewer      string
 }{
 	Admin:       "ADMIN",
 	User:        "USER",
 	Responder:   "RESPONDER",
 	Stakeholder: "STAKEHOLDER",
+	Viewer:      "VIEWER",
 }
 
 // TeamMemberRolesAll defines team member roles list
@@ -47,6 +49,7 @@ var TeamMemberRolesAll = []string{
 	TeamMemberRoles.User,
 	TeamMemberRoles.Responder,
 	TeamMemberRoles.Stakeholder,
+	TeamMemberRoles.Viewer,
 }
 
 // TeamVisibility defines team visibility

--- a/user.go
+++ b/user.go
@@ -50,10 +50,12 @@ var UserRole = struct {
 	User        string
 	Admin       string
 	Stakeholder string
+	Viewer      string
 }{
 	User:        "USER",
 	Admin:       "ADMIN",
 	Stakeholder: "STAKEHOLDER",
+	Viewer:      "VIEWER",
 }
 
 // UserRoleAll defines user roles list
@@ -61,6 +63,7 @@ var UserRoleAll = []string{
 	UserRole.User,
 	UserRole.Admin,
 	UserRole.Stakeholder,
+	UserRole.Viewer,
 }
 
 // CreateUserInput represents the input of a CreateUser operation.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.22.0"
+const Version = "v3.23.0"


### PR DESCRIPTION
- add `closeCode`, `assignmentGroup`, `ownerGroup`, `service`, `serviceOffering` and `contactType` fields to `AlertActionParamsServiceNow`
- add `noteType`, `notePublish` and `status` fields to `AlertActionParamsAutotask`
- add `alias` field to `Service`
- add `disableTranscription` field to `CallFlowNodeMetadata` for `VOICEMAIL` call flow nodes
- add `VIEWER` to `UserRole` and `TeamMemberRoles`
- fix reading Autotask alert actions and connections: `companyId`/`queueId` are returned by the API as JSON strings and previously failed to unmarshal; `queueId` now tolerates both encodings, and the output `companyId` is typed `string` to match the API and the create/update params (source-breaking for code reading it as `int64`, but it never unmarshalled successfully before)