### PR TITLE
Fix/alert source teams clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 30.07.2026, Version 3.23.1
 
-- fix `AlertSource.Teams` never being able to clear an alert source's teams: the field was tagged `omitempty`, so an empty slice was dropped from the payload and the API left the existing teams in place (it only clears them on an explicit empty array; an omitted or `null` field is a no-op). The tag is now `json:"teams"` so an empty slice marshals to `"teams":[]`. Callers that relied on a `nil` `Teams` meaning "leave untouched" are unaffected, since `nil` still marshals to `null`, which the API ignores.
+- fix `AlertSource.Teams` never being able to clear an alert source's teams: the field was tagged `omitempty`, so an empty slice was dropped from the payload and the API left the existing teams in place (it only clears them on an explicit empty array; an omitted or `null` field is a no-op). The tag is now `json:"teams"` so an empty slice marshals to `"teams":[]`. Callers that relied on a `nil` `Teams` meaning "leave untouched" are unaffected, since `nil` still marshals to `null`, which the API ignores. [#76](https://github.com/iLert/ilert-go/pull/76)
 
 ## 22.07.2026, Version 3.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 30.07.2026, Version 3.23.1
+
+- fix `AlertSource.Teams` never being able to clear an alert source's teams: the field was tagged `omitempty`, so an empty slice was dropped from the payload and the API left the existing teams in place (it only clears them on an explicit empty array; an omitted or `null` field is a no-op). The tag is now `json:"teams"` so an empty slice marshals to `"teams":[]`. Callers that relied on a `nil` `Teams` meaning "leave untouched" are unaffected, since `nil` still marshals to `null`, which the API ignores.
+
 ## 22.07.2026, Version 3.23.0
 
 - **Source-compatibility note:** the output `CompanyID` field on `AlertActionOutputParams` and `ConnectionOutputParams` changes type from `int64` to `string` (see the Autotask fix below). This is source-breaking for code referencing those fields as `int64`, but it ships in a minor release because the fields never unmarshalled successfully before, so no working caller could depend on the `int64` form. [#73](https://github.com/iLert/ilert-go/pull/73)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 30.07.2026, Version 3.23.1
+## 03.08.2026, Version 3.23.1
 
 - fix `AlertSource.Teams` never being able to clear an alert source's teams: the field was tagged `omitempty`, so an empty slice was dropped from the payload and the API left the existing teams in place (it only clears them on an explicit empty array; an omitted or `null` field is a no-op). The tag is now `json:"teams"` so an empty slice marshals to `"teams":[]`. Callers that relied on a `nil` `Teams` meaning "leave untouched" are unaffected, since `nil` still marshals to `null`, which the API ignores. [#76](https://github.com/iLert/ilert-go/pull/76)
 

--- a/alert_source.go
+++ b/alert_source.go
@@ -38,7 +38,7 @@ type AlertSource struct {
 	Metadata               map[string]interface{} `json:"metadata,omitempty"`         // @deprecated
 	AutotaskMetadata       *AutotaskMetadata      `json:"autotaskMetadata,omitempty"` // @deprecated
 	Heartbeat              *Heartbeat             `json:"heartbeat,omitempty"`        // @deprecated
-	Teams                  []TeamShort            `json:"teams,omitempty"`
+	Teams                  []TeamShort            `json:"teams"`
 	SummaryTemplate        *Template              `json:"summaryTemplate,omitempty"`
 	DetailsTemplate        *Template              `json:"detailsTemplate,omitempty"`
 	RoutingTemplate        *Template              `json:"routingTemplate,omitempty"`

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.23.0"
+const Version = "v3.23.1"


### PR DESCRIPTION
- fix alert source teams not being clearable: an empty slice was dropped by omitempty, so the API left the existing teams in place