### PR TITLE
Feature/user purchase seat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 01.09.2026, Version 3.25.0
+
+- add `PurchaseSeat` to `CreateUserInput`, mapping to the `purchase-seat` query parameter of `POST /users`. The API then buys a license for the account instead of validating its license quota, which charges the account, prorated for the rest of the billing period. The purchase is unconditional, the API does not check whether a free seat is available first, so the field is only sent when it is set explicitly; the account also needs an active paid subscription and admin seat purchase enabled or the API rejects the request [#80](https://github.com/iLert/ilert-go/pull/80)
+- add a `Bool` pointer helper alongside `String`, `Int64` and `Int`, so the `*bool` input fields (`PurchaseSeat`, `SendNoInvitation`, `AbortOnGaps`, `ExcludeOverrides`) can be set without hand-rolling a pointer [#80](https://github.com/iLert/ilert-go/pull/80)
+
 ## 17.08.2026, Version 3.24.0
 
 - add `LinkTextTemplate` to alert source `LinkTemplate`. The API superseded the plain `text` display name with the templatable `linkTextTemplate` and no longer returns `text` for link templates that use it, so those link templates previously read back with an empty `Text`. `Text` is kept and still accepted by the API as the legacy fallback, but is now deprecated; at least one of the two must be set or the API rejects the request [#77](https://github.com/iLert/ilert-go/pull/77)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 01.09.2026, Version 3.25.0
+## 09.09.2026, Version 3.25.0
 
 - add `PurchaseSeat` to `CreateUserInput`, mapping to the `purchase-seat` query parameter of `POST /users`. The API then buys a license for the account instead of validating its license quota, which charges the account, prorated for the rest of the billing period. The purchase is unconditional, the API does not check whether a free seat is available first, so the field is only sent when it is set explicitly; the account also needs an active paid subscription and admin seat purchase enabled or the API rejects the request [#80](https://github.com/iLert/ilert-go/pull/80)
 - add a `Bool` pointer helper alongside `String`, `Int64` and `Int`, so the `*bool` input fields (`PurchaseSeat`, `SendNoInvitation`, `AbortOnGaps`, `ExcludeOverrides`) can be set without hand-rolling a pointer [#80](https://github.com/iLert/ilert-go/pull/80)

--- a/examples/user/main.go
+++ b/examples/user/main.go
@@ -16,4 +16,24 @@ func main() {
 		log.Fatalln("ERROR:", err.Error())
 	}
 	log.Printf("User:\n\n %+v\n", result.User)
+
+	input := ilert.CreateUserInput{
+		User: &ilert.User{
+			FirstName: "your first name",
+			LastName:  "your last name",
+			Email:     "your email",
+			Role:      ilert.UserRole.User,
+		},
+		SendNoInvitation: ilert.Bool(true),
+
+		// set to true to buy a license for this user instead of checking the account
+		// quota, this always buys a seat and charges the account for it
+		PurchaseSeat: ilert.Bool(false),
+	}
+	createResult, err := client.CreateUser(&input)
+	if err != nil {
+		log.Println(createResult)
+		log.Fatalln("ERROR:", err.Error())
+	}
+	log.Printf("User successfully created!\n\n %+v\n", createResult.User)
 }

--- a/helper.go
+++ b/helper.go
@@ -15,6 +15,11 @@ func Int(v int) *int {
 	return &v
 }
 
+// Bool returns a pointer to the bool value passed in.
+func Bool(v bool) *bool {
+	return &v
+}
+
 func intSliceContains(s []int, e int) bool {
 	for _, a := range s {
 		if a == e {

--- a/user.go
+++ b/user.go
@@ -71,6 +71,15 @@ type CreateUserInput struct {
 	_                struct{}
 	User             *User
 	SendNoInvitation *bool
+
+	// PurchaseSeat buys a license for the account instead of validating its license
+	// quota. The purchase is unconditional: the API does not check whether a free
+	// seat is available first, so a create with this set always buys a seat and the
+	// account is charged for it, prorated for the rest of the billing period. Only
+	// set it when the caller has explicitly asked for it, and only when the account
+	// has actually run out of licenses. Requires the account to have an active paid
+	// subscription and admin seat purchase enabled.
+	PurchaseSeat *bool
 }
 
 // CreateUserOutput represents the output of a CreateUser operation.
@@ -92,9 +101,17 @@ func (c *Client) CreateUser(input *CreateUserInput) (*CreateUserOutput, error) {
 		return nil, errors.New("user input is required")
 	}
 
-	requestURL := apiRoutes.users
+	q := url.Values{}
 	if input.SendNoInvitation != nil {
-		requestURL = fmt.Sprintf("%s?send-no-invitation=%t", apiRoutes.users, *input.SendNoInvitation)
+		q.Add("send-no-invitation", strconv.FormatBool(*input.SendNoInvitation))
+	}
+	if input.PurchaseSeat != nil {
+		q.Add("purchase-seat", strconv.FormatBool(*input.PurchaseSeat))
+	}
+
+	requestURL := apiRoutes.users
+	if len(q) > 0 {
+		requestURL = fmt.Sprintf("%s?%s", apiRoutes.users, q.Encode())
 	}
 
 	resp, err := c.httpClient.R().SetBody(input.User).Post(requestURL)

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,76 @@
+package ilert
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// TestCreateUserQueryParams verifies which query parameters CreateUser puts on the
+// request. purchase-seat buys a license and charges the account for it, so it must
+// never reach the API unless the caller set it explicitly.
+// See iLert/engineering-tasks#2391.
+func TestCreateUserQueryParams(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  *CreateUserInput
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name:   "no options",
+			input:  &CreateUserInput{User: &User{Email: "test@example.com"}},
+			want:   map[string]string{},
+			absent: []string{"send-no-invitation", "purchase-seat"},
+		},
+		{
+			name:   "purchase seat",
+			input:  &CreateUserInput{User: &User{Email: "test@example.com"}, PurchaseSeat: Bool(true)},
+			want:   map[string]string{"purchase-seat": "true"},
+			absent: []string{"send-no-invitation"},
+		},
+		{
+			name:   "purchase seat disabled",
+			input:  &CreateUserInput{User: &User{Email: "test@example.com"}, PurchaseSeat: Bool(false)},
+			want:   map[string]string{"purchase-seat": "false"},
+			absent: []string{"send-no-invitation"},
+		},
+		{
+			name: "both options",
+			input: &CreateUserInput{
+				User:             &User{Email: "test@example.com"},
+				SendNoInvitation: Bool(true),
+				PurchaseSeat:     Bool(true),
+			},
+			want: map[string]string{"send-no-invitation": "true", "purchase-seat": "true"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var query url.Values
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				query = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"id":1,"email":"test@example.com"}`))
+			}))
+			defer srv.Close()
+
+			if _, err := newTestClient(t, srv.URL).CreateUser(tc.input); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for key, want := range tc.want {
+				if got := query.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			}
+			for _, key := range tc.absent {
+				if _, ok := query[key]; ok {
+					t.Errorf("query contains %s = %q, want it to be absent", key, query.Get(key))
+				}
+			}
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package ilert
 
 // Version package version
-const Version = "v3.24.0"
+const Version = "v3.25.0"


### PR DESCRIPTION
- add `PurchaseSeat` to `CreateUserInput`, mapping to the `purchase-seat` query parameter of `POST /users`: the API then buys a license for the account instead of validating its license quota, which charges the account, prorated for the rest of the billing period
- the purchase is unconditional, the API does not check whether a free seat is available first, so the field is only sent when it is set explicitly; the account also needs an active paid subscription and admin seat purchase enabled or the API rejects the request
- add a `Bool` pointer helper alongside `String`, `Int64` and `Int`, so the `*bool` input fields (`PurchaseSeat`, `SendNoInvitation`, `AbortOnGaps`, `ExcludeOverrides`) can be set without hand-rolling a pointer